### PR TITLE
add missing if parentheses causing compilation failure 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ $(APPS): %: $(OBJECTS) $(INCSSRC) %.o
 	@cp $@ bin/.
 
 $(OBJECTS): %.o: %.$(SRCEXT) $(INCSSRC)
-	@echo "+++++++ Genrating dependencies for $< "
+	@echo "+++++++ Generating dependencies for $< "
 	@$(CC) $(CFLAGS) $< -o $@
 
 %.o: %.$(SRCEXT) $(INCSSRC)
-	@echo "------- Genrating application objects for $< "
+	@echo "------- Generating application objects for $< "
 	@$(CC) $(CFLAGS) $< -o $@
 
 .Phony : clean 

--- a/lib/interface/TrustX_Interface.c
+++ b/lib/interface/TrustX_Interface.c
@@ -138,7 +138,9 @@ uint16_t trustX_Reg_Write(uint8_t reg, uint8_t *pData, uint16_t dataLen)
 	{
 		ret = trustX_I2C_Write(pBuffer, dataLen+1);
 		if (ret != INTERFACE_SUCCESS)
+		{
 			DEBUGPRINTINTERFACE(".");
+		}
 		else
 		{
 			break;
@@ -220,7 +222,9 @@ uint16_t trustX_Reg_Read(uint8_t reg, uint8_t *pData, uint16_t *dataLen)
 	{
 		ret = trustX_I2C_Write(pBuffer, 1);
 		if (ret != INTERFACE_SUCCESS)
+		{
 			DEBUGPRINTINTERFACE(".");
+		}
 		else
 		{
 			DEBUGPRINTINTERFACE("Command sended.\n");
@@ -235,7 +239,9 @@ uint16_t trustX_Reg_Read(uint8_t reg, uint8_t *pData, uint16_t *dataLen)
 		{	
 			ret = trustX_I2C_Read(pData, bufLen);
 			if(ret != INTERFACE_SUCCESS)
+			{
 				DEBUGPRINTINTERFACE(".");
+			}
 			else
 			{	
 				*dataLen = bufLen;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Build fails after enabling "#define _DEBUGINTERFACE". Parentheses are missing in three different if statements in TrustX_Interface.c.
Also fix typo in Makefile.

```
------- Genrating application objects for sample/trustx_reg.c 
lib/interface/TrustX_Interface.c: In function ‘trustX_Reg_Write’:
lib/interface/TrustX_Interface.c:142:3: error: ‘else’ without a previous ‘if’
   else
   ^~~~
lib/interface/TrustX_Interface.c: In function ‘trustX_Reg_Read’:
lib/interface/TrustX_Interface.c:224:3: error: ‘else’ without a previous ‘if’
   else
   ^~~~
lib/interface/TrustX_Interface.c:239:4: error: ‘else’ without a previous ‘if’
    else
    ^~~~
make[2]: *** [Makefile:60: lib/interface/TrustX_Interface.o] Error 1
```