### PR TITLE
use the i2cAddr variable instead of the ADDR define for debug messages

### DIFF
--- a/lib/interface/TrustX_Interface.c
+++ b/lib/interface/TrustX_Interface.c
@@ -72,10 +72,10 @@ uint16_t trustX_I2C_Open(uint8_t i2cAddr)
 	if (ioctl(pTrustX_I2C_Handle, I2C_SLAVE, i2cAddr) < 0)
 	{
 		// Error Handling
-		ERRORPRINTINTERFACE("Failed to acquire i2c bus access at 0x%.2x \n",TRUSTX_I2C_ADDR);
+		ERRORPRINTINTERFACE("Failed to acquire i2c bus access at 0x%.2x \n", i2cAddr);
 		return INTERFACE_ERR_SLAVE_ADDR;
 	}
-	DEBUGPRINTINTERFACE("i2c bus acquire address: 0x%.2x \n",TRUSTX_I2C_ADDR);
+	DEBUGPRINTINTERFACE("i2c bus acquire address: 0x%.2x \n", i2cAddr);
 
 	return INTERFACE_SUCCESS;
 }


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
The debug messages print the same address when scanning each different address.
Use the i2cAddr variable instead of using the define with the TrustX Address.

Please see the following output and note that 0x30 is listed for all the addresses.
```
$ trustx_scan -b /dev/i2c-0
WARNING! This program can confuse your I2C bus, cause data loss and worse!
I will probe file /dev/i2c-0 using read byte commands.
I will probe address range 0x00-0x7F.
Continue? [Y/n]
Y
------------------------------------------------------
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
<snip></snip>
```