### PR TITLE
do not exit program if i2c address is already in use by the kernel

### DIFF
--- a/sample/trustx_scan.c
+++ b/sample/trustx_scan.c
@@ -147,28 +147,35 @@ int main(int argc, char **argv)
 			continue;
 			
 		ret = trustX_I2C_Open(j);
-		if (ret != INTERFACE_SUCCESS)
+		if ((ret != INTERFACE_SUCCESS) && (ret != INTERFACE_ERR_SLAVE_ADDR))
 		{
 			printf("Interface Open error!!!\n");
 			return -1;
 		}
 
-		for(i=0;i<2;i++)
+		if (ret != INTERFACE_ERR_SLAVE_ADDR)
 		{
-			ret = trustX_I2C_Read(pData,1);
-			if(ret != INTERFACE_SUCCESS)
+			for(i=0;i<2;i++)
 			{
-				pDetected[j] = 0x00;
+				ret = trustX_I2C_Read(pData,1);
+				if(ret != INTERFACE_SUCCESS)
+				{
+					pDetected[j] = 0x00;
+				}
+				else
+				{
+					pDetected[j] = 0x01;
+					break;
+				}
+				usleep(500);
 			}
-			else
-			{
-				pDetected[j] = 0x01;
-				break;
-			}
-			usleep(500);
-		}
 
-		trustX_I2C_Close();	
+			trustX_I2C_Close();
+		}
+		else if (ret == INTERFACE_ERR_SLAVE_ADDR)
+		{
+			pDetected[j] = 0x55;
+		}
 	}
 
 	printf("     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f");
@@ -178,11 +185,21 @@ int main(int argc, char **argv)
 			printf("\n%.2x : ",j);
 		
 		if (pDetected[j] == 1)
+		{
 			printf("%.2x ",j);
+		}
 		else if (pDetected[j] == 0xff)
+		{
 			printf("   ");
+		}
+		else if (pDetected[j] == 0x55)
+		{
+			printf("UU ");
+		}
 		else
+		{
 			printf("-- ");
+		}
 	}
 	printf("\n");
 	return ret;


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
trustx_scan:
In it's current implementation in master, if the device is in use by the kernel the program will exit prematurely. i2cdetect for example, continues scanning but uses "UU" to indicate the device is in use.
This PR adds the 'UU' functionality so that the trustx_scan does not exit and will continue scanning the entire range.

Previously the program would error out and exit like so: (0x38 was in use by the kernel)
```
$ trustx_scan -b /dev/i2c-0
WARNING! This program can confuse your I2C bus, cause data loss and worse!
I will probe file /dev/i2c-0 using read byte commands.
I will probe address range 0x00-0x7F.
Continue? [Y/n]
Y
------------------------------------------------------
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
<snip></snip>
[INTERFACE]i2c_handle open Success. 
[INTERFACE]i2c bus acquire address: 0x30 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]pBuffer[0] = 0x00 
[INTERFACE]i2c_handle open Success. 
[INTERFACE]Failed to acquire i2c bus access at 0x30 
Interface Open error!!!
```

This is an example output of i2cdetect:
```
$ i2cdetect -y 0
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- UU -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: -- -- -- -- -- -- -- -- 
```

After this patch trustx_scan shows the following results:
```
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00 :                         -- -- -- -- -- -- -- -- 
10 : -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20 : -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30 : 30 -- -- -- UU -- -- -- -- -- -- -- -- -- -- -- 
40 : -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
50 : -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60 : -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70 : -- -- -- -- -- -- -- -- -- -- -- --   
```
